### PR TITLE
fix bug causing incorrect likelihood calculations with SSE on non-4-state models

### DIFF
--- a/libhmsbeagle/CPU/BeagleCPUSSEImpl.hpp
+++ b/libhmsbeagle/CPU/BeagleCPUSSEImpl.hpp
@@ -224,8 +224,8 @@ void BeagleCPUSSEImpl<BEAGLE_CPU_SSE_DOUBLE>::calcPartialsPartials(double* __res
     int stateCountMinusOne = kPartialsPaddedStateCount - 1;
 #pragma omp parallel for num_threads(kCategoryCount)
     for (int l = 0; l < kCategoryCount; l++) {
-    	double* destPu = destP + l*kPartialsPaddedStateCount*kPatternCount + startPattern*kPartialsPaddedStateCount;;
-    	int v = l*kPartialsPaddedStateCount*kPatternCount;
+    	int v = l*kPartialsPaddedStateCount*kPatternCount + kPartialsPaddedStateCount*startPattern;
+    	double* destPu = destP + v;
         for (int k = startPattern; k < endPattern; k++) {
             int w = l * kMatrixSize;
             for (int i = 0; i < kStateCount;


### PR DESCRIPTION
Beagle double-precision SSE was calculating likelihoods incorrectly for amino-acid and presumably other non-4-state models (calcPartialsPartials in BeagleCPUSSEImpl.hpp).