### PR TITLE
Fix calcEdgeLogDerivativesStates implementations.

### DIFF
--- a/libhmsbeagle/CPU/BeagleCPU4StateImpl.hpp
+++ b/libhmsbeagle/CPU/BeagleCPU4StateImpl.hpp
@@ -1024,18 +1024,22 @@ void BeagleCPU4StateImpl<BEAGLE_CPU_GENERIC>::calcEdgeLogDerivativesStates(const
 
             const int state = tipStates[pattern];
 
-            PREFETCH_MATRIX_COLUMN(0, firstDerivMatrix, state);
+            if(state < kStateCount){
+                PREFETCH_MATRIX_COLUMN(0, firstDerivMatrix, state);
+                REALTYPE numerator = sum00 * preOrderPartial[localPatternOffset] +
+                sum01 * preOrderPartial[localPatternOffset + 1] +
+                sum02 * preOrderPartial[localPatternOffset + 2] +
+                sum03 * preOrderPartial[localPatternOffset + 3];
 
-            REALTYPE numerator =
-                    sum00 * preOrderPartial[localPatternOffset] +
-                    sum01 * preOrderPartial[localPatternOffset + 1] +
-                    sum02 * preOrderPartial[localPatternOffset + 2] +
-                    sum03 * preOrderPartial[localPatternOffset + 3];
+                REALTYPE denominator = preOrderPartial[localPatternOffset + state];
 
-            REALTYPE denominator = preOrderPartial[localPatternOffset + state];
-
-            grandNumeratorDerivTmp[pattern] += categoryWeights[category] * numerator;
-            grandDenominatorDerivTmp[pattern] += categoryWeights[category] * denominator;
+                grandNumeratorDerivTmp[pattern] += categoryWeights[category] * numerator;
+                grandDenominatorDerivTmp[pattern] += categoryWeights[category] * denominator;
+            }
+            else{
+                grandNumeratorDerivTmp[pattern] = 0;
+                grandDenominatorDerivTmp[pattern] = 1; // anything but 0
+            }
         }
     }
 }

--- a/libhmsbeagle/CPU/BeagleCPU4StateSSEImpl.hpp
+++ b/libhmsbeagle/CPU/BeagleCPU4StateSSEImpl.hpp
@@ -760,18 +760,26 @@ void BeagleCPU4StateSSEImpl<BEAGLE_CPU_4_SSE_DOUBLE>::calcEdgeLogDerivativesStat
 
             const int stateChild = statesChild[k];
 
-            V_Real p01, p23;
-            p01 = VEC_MULT(vu_m[stateChild][0].vx, *vcl_r++);
-            p23 = VEC_MULT(vu_m[stateChild][1].vx, *vcl_r++);
+            if(stateChild < kStateCount){
+                V_Real p01, p23;
+                p01 = VEC_MULT(vu_m[stateChild][0].vx, *vcl_r++);
+                p23 = VEC_MULT(vu_m[stateChild][1].vx, *vcl_r++);
 
-            V_Real vnumer = VEC_ADD(p01, p23);
-            vnumer = VEC_ADD(vnumer, VEC_SWAP(vnumer));
+                V_Real vnumer = VEC_ADD(p01, p23);
+                vnumer = VEC_ADD(vnumer, VEC_SWAP(vnumer));
 
-            double numer = _mm_cvtsd_f64(vnumer);
-            double denom = cl_r[stateChild]; cl_r += 4;
+                double numer = _mm_cvtsd_f64(vnumer);
+                double denom = cl_r[stateChild];
 
-            grandNumeratorDerivTmp[k] += numer * wt[l];
-            grandDenominatorDerivTmp[k] += denom * wt[l];
+                grandNumeratorDerivTmp[k] += numer * wt[l];
+                grandDenominatorDerivTmp[k] += denom * wt[l];
+            }
+            else{
+                vcl_r += 2;
+                grandNumeratorDerivTmp[k] = 0;
+                grandDenominatorDerivTmp[k] = 1;
+            }
+            cl_r += 4;
         }
         w += OFFSET*4;
         vcl_r += 2 * kExtraPatterns;

--- a/libhmsbeagle/CPU/BeagleCPUImpl.hpp
+++ b/libhmsbeagle/CPU/BeagleCPUImpl.hpp
@@ -1994,16 +1994,22 @@ void BeagleCPUImpl<BEAGLE_CPU_GENERIC>::calcEdgeLogDerivativesStates(const int *
             const int patternIndex = category * kPatternCount + pattern;
             const int state = tipStates[pattern];
 
-            REALTYPE numerator = 0.0;
-            REALTYPE denominator = preOrderPartial[patternIndex * kPartialsPaddedStateCount + state];
+            if(state < kStateCount){
+                REALTYPE numerator = 0.0;
+                REALTYPE denominator = preOrderPartial[patternIndex * kPartialsPaddedStateCount + state];
 
-            for (int k = 0; k < kStateCount; k++) {
-                numerator += firstDerivMatrix[category * kMatrixSize + k * kTransPaddedStateCount + state] *
-                             preOrderPartial[patternIndex * kPartialsPaddedStateCount + k];
+                for (int k = 0; k < kStateCount; k++) {
+                    numerator += firstDerivMatrix[category * kMatrixSize + k * kTransPaddedStateCount + state] *
+                                 preOrderPartial[patternIndex * kPartialsPaddedStateCount + k];
+                }
+
+                grandNumeratorDerivTmp[pattern] += categoryWeights[category] * numerator;
+                grandDenominatorDerivTmp[pattern] += categoryWeights[category] * denominator;
             }
-
-            grandNumeratorDerivTmp[pattern] += categoryWeights[category] * numerator;
-            grandDenominatorDerivTmp[pattern] += categoryWeights[category] * denominator;
+            else{
+                grandNumeratorDerivTmp[pattern] = 0;
+                grandDenominatorDerivTmp[pattern] = 1; // anything but 0
+            }
         }
     }
 }


### PR DESCRIPTION
calcEdgeLogDerivativesStates was not taking undefined states (e.g. gaps) into account, potentially causing out of bound indexing in preOrderPartial array.