### PR TITLE
Fix macOS rpath for non-default prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if(APPLE)
 	endif()
 
 	# Seems necessary from macOS 10.15
-	set(CMAKE_INSTALL_RPATH "/usr/local/lib")
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif(APPLE)
 
 if (BEAGLE_OPTIMIZE_FOR_NATIVE_ARCH)


### PR DESCRIPTION
Installing to a non-/usr/local prefix by setting `CMAKE_INSTALL_PREFIX` on macOS will result in libhmsbeagle-jni.jnilib failing to load: 

```console
% beast -beagle_info
Failed to load BEAGLE library: /opt/homebrew/Cellar/beagle/4.0alpha/lib/libhmsbeagle-jni.jnilib: dlopen(/opt/homebrew/Cellar/beagle/4.0alpha/lib/libhmsbeagle-jni.jnilib, 1): Library not loaded: @rpath/libhmsbeagle.dylib
  Referenced from: /opt/homebrew/Cellar/beagle/4.0alpha/lib/libhmsbeagle-jni.jnilib
  Reason: image not found
```

This is because the rpath is improperly set to /usr/local:

```console
% otool -l libhmsbeagle-jni.jnilib| grep -i rpath -A2
         name @rpath/libhmsbeagle.dylib (offset 24)
   time stamp 2 Wed Dec 31 16:00:02 1969
      current version 0.0.0
--
          cmd LC_RPATH
      cmdsize 32
         path /usr/local/lib (offset 12)
```

This patch taken from a [recommendation on the cmake wiki](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#always-full-rpath). After applying this patch the rpath is correctly set to the install prefix:

```console
% otool -l libhmsbeagle-jni.jnilib | grep -i rpath -A2
         name @rpath/libhmsbeagle.dylib (offset 24)
   time stamp 2 Wed Dec 31 16:00:02 1969
      current version 0.0.0
--
          cmd LC_RPATH
      cmdsize 56
         path /opt/homebrew/Cellar/beagle/4.0alpha/lib (offset 12)
```