### PR TITLE
Fix action bug on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,12 @@ if(APPLE)
 
 	# Seems necessary from macOS 10.15
 	SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+elseif(UNIX)
+        # This tells libhmsbeagle.so to search the same directory to find plugins.
+        SET(CMAKE_INSTALL_RPATH "\$ORIGIN")
+        # $ORIGIN/{CPU,GPU,JNI} is so that libhmsbeagle.so can find the plugins in their build location.
+        # $ORIGIN/../libhmsbeagle is so that examples/* can find libhmsbeagle.so
+	SET(CMAKE_BUILD_RPATH "\$ORIGIN;\$ORIGIN/CPU;\$ORIGIN/GPU;\$ORIGIN/JNI;\$ORIGIN/../libhmsbeagle")
 endif(APPLE)
 
 if (BEAGLE_OPTIMIZE_FOR_NATIVE_ARCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,21 +46,31 @@ add_definitions(
 	)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-#SET(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 
 ## flags for standard library
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 if(WIN32)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox /Ot /MT")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MT")
 else(WIN32)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -pthread")
-	#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -pthread")
-	#set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 endif(WIN32)
+
+if (NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
+        if(WIN32)
+	        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox /Ot")
+        else(WIN32)
+	        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+        	#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+	        #set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
+        endif(WIN32)
+endif()
 
 #if(NOT WIN32)
 #    add_definitions(-DHAVE_CONFIG_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ elseif(UNIX)
         SET(CMAKE_INSTALL_RPATH "\$ORIGIN")
         # $ORIGIN/{CPU,GPU,JNI} is so that libhmsbeagle.so can find the plugins in their build location.
         # $ORIGIN/../libhmsbeagle is so that examples/* can find libhmsbeagle.so
-	SET(CMAKE_BUILD_RPATH "\$ORIGIN;\$ORIGIN/CPU;\$ORIGIN/GPU;\$ORIGIN/JNI;\$ORIGIN/../libhmsbeagle")
+	SET(CMAKE_BUILD_RPATH "\$ORIGIN:\$ORIGIN/CPU:\$ORIGIN/GPU:\$ORIGIN/JNI:\$ORIGIN/../libhmsbeagle")
 endif(APPLE)
 
 if (BEAGLE_OPTIMIZE_FOR_NATIVE_ARCH)

--- a/libhmsbeagle/CPU/BeagleCPUActionImpl.h
+++ b/libhmsbeagle/CPU/BeagleCPUActionImpl.h
@@ -235,15 +235,15 @@ namespace beagle {
                                           MapType *partials2, int edgeIndex1,
                                           int edgeIndex2, MapType *partialCache2);
 
-            void getStatistics(double A1Norm,
-                               SpMatrix * matrix,
-                               double t,
-                               int nCol,
-                               int &m,
-                               int &s);
+	    // Return (m,s)
+	    std::tuple<int,int> getStatistics(double A1Norm,
+					      SpMatrix * matrix,
+					      double t,
+					      int nCol);
 
-            void getStatistics2(double t, int nCol, int &m, int &s, double edgeMultiplier,
-                                int eigenIndex);
+	    // Return (m,s)
+	    std::tuple<int,int> getStatistics2(double t, int nCol, double edgeMultiplier,
+					       int eigenIndex);
 
             double getDValue(int p,
                              std::map<int, double> &d,

--- a/libhmsbeagle/CPU/BeagleCPUActionImpl.hpp
+++ b/libhmsbeagle/CPU/BeagleCPUActionImpl.hpp
@@ -482,11 +482,10 @@ namespace beagle {
                 const double tol = pow(2.0, -53.0);
                 const double t = 1.0;
                 const int nCol = kPatternCount;
-                int m, s;
 
                 const double edgeMultiplier = gEdgeMultipliers[edgeIndex * kCategoryCount + category];
 
-                getStatistics2(t, nCol, m, s, edgeMultiplier, gEigenMaps[edgeIndex]);
+                auto [m,s] = getStatistics2(t, nCol, edgeMultiplier, gEigenMaps[edgeIndex]);
 
 
 #ifdef BEAGLE_DEBUG_FLOW
@@ -528,61 +527,69 @@ namespace beagle {
         }
 
         BEAGLE_CPU_ACTION_TEMPLATE
-        void BeagleCPUActionImpl<BEAGLE_CPU_ACTION_DOUBLE>::getStatistics2(double t, int nCol, int &m, int &s,
-                                                                           double edgeMultiplier,
-                                                                           int eigenIndex) {
-            if (t * gB1Norms[eigenIndex] == 0.0) {
-                m = 0;
-                s = 1;
-            } else {
-                int bestM = INT_MAX;
-                int bestS = INT_MAX;
+        std::tuple<int,int>
+	BeagleCPUActionImpl<BEAGLE_CPU_ACTION_DOUBLE>::getStatistics2(double t, int nCol,
+								      double edgeMultiplier,
+								      int eigenIndex) {
+	    assert( t >= 0 );
+	    assert( nCol >= 0);
+	    assert( edgeMultiplier >= 0 );
+	    assert( eigenIndex >= 0);
 
-                const double theta = thetaConstants[mMax];
-                const double pMax = floor((0.5 + 0.5 * sqrt(5.0 + 4.0 * mMax)));
-                // pMax is the largest positive integer such that p*(p-1) <= mMax + 1
+            if (t * gB1Norms[eigenIndex] == 0.0)
+		return {0, 1};
 
-                const bool conditionFragment313 = gB1Norms[eigenIndex] * edgeMultiplier <= 2.0 * theta / ((double) nCol * mMax) * pMax * (pMax + 3);
-                // using l = 1 as in equation 3.13
-                std::map<int, double>::iterator it;
-                if (conditionFragment313) {
-                    for (it = thetaConstants.begin(); it != thetaConstants.end(); it++) {
-                        const int thisM = it->first;
-                        const double thisS = ceil(gB1Norms[eigenIndex] * edgeMultiplier / thetaConstants[thisM]);
-                        if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
-                            bestS = (int) thisS;
-                            bestM = thisM;
-                        }
-                    }
-                    s = bestS;
-                } else {
-                    if (gHighestPowers[eigenIndex] < 1) {
-                        SpMatrix currentMatrix = gBs[eigenIndex];
-                        powerMatrices[eigenIndex][1] = currentMatrix;
-                        ds[eigenIndex][1] = normP1(&currentMatrix);
-                        gHighestPowers[eigenIndex] = 1;
-                    }
-                    for (int p = 2; p < pMax; p++) {
-                        for (int thisM = p * (p - 1) - 1; thisM < mMax + 1; thisM++) {
-                            it = thetaConstants.find(thisM);
-                            if (it != thetaConstants.end()) {
-                                // equation 3.7 in Al-Mohy and Higham
-                                const double dValueP = getDValue2(p, eigenIndex);
-                                const double dValuePPlusOne = getDValue2(p + 1, eigenIndex);
-                                const double alpha = (dValueP > dValuePPlusOne ? dValueP : dValuePPlusOne) * edgeMultiplier;
-                                // part of equation 3.10
-                                const double thisS = ceil(alpha / thetaConstants[thisM]);
-                                if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
-                                    bestS = (int) thisS;
-                                    bestM = thisM;
-                                }
-                            }
-                        }
-                    }
-                    s = bestS > 1 ? bestS : 1;
-                }
-                m = bestM;
-            }
+	    int bestM = INT_MAX;
+	    double bestS = INT_MAX;  // Not all the values of s can fit in a 32-bit int.
+
+	    const double theta = thetaConstants[mMax];
+	    const double pMax = floor((0.5 + 0.5 * sqrt(5.0 + 4.0 * mMax)));
+	    // pMax is the largest positive integer such that p*(p-1) <= mMax + 1
+
+	    const bool conditionFragment313 = gB1Norms[eigenIndex] * edgeMultiplier <= 2.0 * theta / ((double) nCol * mMax) * pMax * (pMax + 3);
+	    // using l = 1 as in equation 3.13
+	    if (conditionFragment313) {
+		for (auto& [thisM, thetaM]: thetaConstants) {
+		    const double thisS = ceil(gB1Norms[eigenIndex] * edgeMultiplier / thetaM);
+		    if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
+			bestS = thisS;
+			bestM = thisM;
+		    }
+		}
+	    } else {
+		if (gHighestPowers[eigenIndex] < 1) {
+		    SpMatrix currentMatrix = gBs[eigenIndex];
+		    powerMatrices[eigenIndex][1] = currentMatrix;
+		    ds[eigenIndex][1] = normP1(&currentMatrix);
+		    gHighestPowers[eigenIndex] = 1;
+		}
+		for (int p = 2; p < pMax; p++) {
+		    for (int thisM = p * (p - 1) - 1; thisM < mMax + 1; thisM++) {
+			auto it = thetaConstants.find(thisM);
+			if (it != thetaConstants.end()) {
+			    // equation 3.7 in Al-Mohy and Higham
+			    const double dValueP = getDValue2(p, eigenIndex);
+			    const double dValuePPlusOne = getDValue2(p + 1, eigenIndex);
+			    const double alpha = (dValueP > dValuePPlusOne ? dValueP : dValuePPlusOne) * edgeMultiplier;
+			    // part of equation 3.10
+			    const double thisS = ceil(alpha / thetaConstants[thisM]);
+			    if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
+				bestS = thisS;
+				bestM = thisM;
+			    }
+			}
+		    }
+		}
+		bestS = std::max(bestS, 1.0);
+	    }
+
+	    int m = bestM;
+	    int s = (int) std::min<double>(bestS, INT_MAX);
+
+	    assert(m >= 0);
+	    assert(s >= 0);
+
+	    return {m,s};
         }
 
 
@@ -620,8 +627,7 @@ namespace beagle {
                 A = thisMatrix - mu * identity;
                 const double A1Norm = normP1(&A);
 
-                int m, s;
-                getStatistics(A1Norm, &A, t, nCol, m, s);
+                auto [m,s] = getStatistics(A1Norm, &A, t, nCol);
 
 #ifdef BEAGLE_DEBUG_FLOW
                 std::cerr<<" m = "<<m<<"  s = "<<s <<std::endl;
@@ -658,59 +664,65 @@ namespace beagle {
 
 
         BEAGLE_CPU_ACTION_TEMPLATE
-        void BeagleCPUActionImpl<BEAGLE_CPU_ACTION_DOUBLE>::getStatistics(double A1Norm, SpMatrix * matrix, double t, int nCol, int &m, int &s) {
-            if (t * A1Norm == 0.0) {
-                m = 0;
-                s = 1;
-            } else {
-                int bestM = INT_MAX;
-                int bestS = INT_MAX;
+        std::tuple<int,int> BeagleCPUActionImpl<BEAGLE_CPU_ACTION_DOUBLE>::getStatistics(double A1Norm, SpMatrix * matrix, double t, int nCol) {
+	    assert( t >= 0 );
+	    assert( A1Norm >= 0.0 );
+	    assert( nCol >= 0 );
 
-                const double theta = thetaConstants[mMax];
-                const double pMax = floor((0.5 + 0.5 * sqrt(5.0 + 4.0 * mMax)));
-                // pMax is the largest positive integer such that p*(p-1) <= mMax + 1
+            if (t * A1Norm == 0.0)
+                return {0,1};
 
-                const bool conditionFragment313 = A1Norm <= 2.0 * theta / ((double) nCol * mMax) * pMax * (pMax + 3);
-                // using l = 1 as in equation 3.13
+	    int bestM = INT_MAX;
+	    double bestS = INT_MAX;
 
-                std::map<int, double>::iterator it;
-                if (conditionFragment313) {
-                    for (it = thetaConstants.begin(); it != thetaConstants.end(); it++) {
-                        const int thisM = it->first;
-                        const double thisS = ceil(A1Norm/thetaConstants[thisM]);
-                        if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
-                            bestS = (int) thisS;
-                            bestM = thisM;
-                        }
-                    }
-                    s = bestS;
-                } else {
-                    std::map<int, double> d;
-                    SpMatrix firstOrderMatrix = *matrix;
-                    std::map<int, SpMatrix> powerMatrices;
-                    powerMatrices[1] = firstOrderMatrix;
-                    d[1] = normP1(&firstOrderMatrix);
-                    for (int p = 2; p < pMax; p++) {
-                        for (int thisM = p * (p - 1) - 1; thisM < mMax + 1; thisM++) {
-                            it = thetaConstants.find(thisM);
-                            if (it != thetaConstants.end()) {
-                                // equation 3.7 in Al-Mohy and Higham
-                                const double dValueP = getDValue(p, d, powerMatrices);
-                                const double dValuePPlusOne = getDValue(p + 1, d, powerMatrices);
-                                const double alpha = dValueP > dValuePPlusOne ? dValueP : dValuePPlusOne;
-                                // part of equation 3.10
-                                const double thisS = ceil(alpha / thetaConstants[thisM]);
-                                if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
-                                    bestS = (int) thisS;
-                                    bestM = thisM;
-                                }
-                            }
-                        }
-                    }
-                    s = bestS > 1 ? bestS : 1;
-                }
-                m = bestM;
-            }
+	    const double theta = thetaConstants[mMax];
+	    const double pMax = floor((0.5 + 0.5 * sqrt(5.0 + 4.0 * mMax)));
+	    // pMax is the largest positive integer such that p*(p-1) <= mMax + 1
+
+	    const bool conditionFragment313 = A1Norm <= 2.0 * theta / ((double) nCol * mMax) * pMax * (pMax + 3);
+	    // using l = 1 as in equation 3.13
+
+	    if (conditionFragment313) {
+		for (auto& [thisM, thetaM]: thetaConstants) {
+		    const double thisS = ceil(A1Norm/thetaM);
+		    if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
+			bestS = thisS;
+			bestM = thisM;
+		    }
+		}
+	    } else {
+		std::map<int, double> d;
+		SpMatrix firstOrderMatrix = *matrix;
+		std::map<int, SpMatrix> powerMatrices;
+		powerMatrices[1] = firstOrderMatrix;
+		d[1] = normP1(&firstOrderMatrix);
+		for (int p = 2; p < pMax; p++) {
+		    for (int thisM = p * (p - 1) - 1; thisM < mMax + 1; thisM++) {
+			auto it = thetaConstants.find(thisM);
+			if (it != thetaConstants.end()) {
+			    // equation 3.7 in Al-Mohy and Higham
+			    const double dValueP = getDValue(p, d, powerMatrices);
+			    const double dValuePPlusOne = getDValue(p + 1, d, powerMatrices);
+			    const double alpha = dValueP > dValuePPlusOne ? dValueP : dValuePPlusOne;
+			    // part of equation 3.10
+			    const double thisS = ceil(alpha / thetaConstants[thisM]);
+			    if (bestM == INT_MAX || ((double) thisM) * thisS < bestM * bestS) {
+				bestS = (int) thisS;
+				bestM = thisM;
+			    }
+			}
+		    }
+		}
+		bestS = std::max(bestS, 1.0);
+	    }
+
+	    int m = bestM;
+	    int s = (int) std::min<double>(bestS, INT_MAX);
+
+	    assert(m >= 0);
+	    assert(s >= 0);
+
+	    return {m,s};
         }
 
         BEAGLE_CPU_ACTION_TEMPLATE


### PR DESCRIPTION
The two main changes are:
- set the build and install rpaths  on LInux to look for plugins relative to the location of the BEAGLE library
- fix the action computation on Linux by not converting `s` to a 32-bit int until we are done.

This PR might be easiest reviewed commit-by-commit.

Thoughts?