### PR TITLE
Don't make the last partition extra-big.

### DIFF
--- a/libhmsbeagle/CPU/BeagleCPUImpl.hpp
+++ b/libhmsbeagle/CPU/BeagleCPUImpl.hpp
@@ -464,7 +464,7 @@ int BeagleCPUImpl<BEAGLE_CPU_GENERIC>::createInstance(int tipCount,
 
             std::vector<int> partitionForPattern(kPatternCount);
             for (int p=0; p<kPatternCount; p++) {
-                partitionForPattern[p] = floor(  (double(p)/kPatternCount) * partitionCount  );
+                partitionForPattern[p] = (p * partitionCount) / kPatternCount;
             }
             setPatternPartitions(partitionCount, partitionForPattern.data());
 
@@ -537,7 +537,7 @@ int BeagleCPUImpl<BEAGLE_CPU_GENERIC>::setCPUThreadCount(int threadCount) {
 
             std::vector<int> partitionForPattern(kPatternCount);
             for (int p=0; p<kPatternCount; p++) {
-                partitionForPattern[p] = floor(  (double(p)/kPatternCount) * partitionCount  );
+                partitionForPattern[p] = (p * partitionCount) / kPatternCount;
             }
             setPatternPartitions(partitionCount, partitionForPattern.data());
 


### PR DESCRIPTION
BEAGLE rounds down when computing the number of site per partitions.  This makes the last partition extra-big.  This tends to be more significant when the number of patterns is not very big (e.g. 90) and the number of threads is relatively prime (i.e. 7).

Instead, compute the partition index for each pattern by linear interpolation.  This way some partitions have N sites and some have N+1, and the last partition doesn't get all the extra.