### PR TITLE
Fix setting Debug mode from IDE/command line.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,20 +35,27 @@ add_definitions(
 
 set(CMAKE_CXX_STANDARD 11)
 
-#SET(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 
 ## flags for standard library
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 if(WIN32)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox /Ot /MT")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MT")
 else(WIN32)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -pthread")
-	#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -pthread")
-	#set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
 endif(WIN32)
+
+if (NOT "${CMAKE_BUILD_TYPE}" MATCHES Debug)
+        if(WIN32)
+	        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox /Ot")
+        else(WIN32)
+	        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+        endif(WIN32)
+endif()
 
 #if(NOT WIN32)
 #    add_definitions(-DHAVE_CONFIG_H)


### PR DESCRIPTION
Typically in cmake to compile in debug mode, you would add -DCMAKE_BUILD_TYPE=Debug to the cmake command line.  In addition to the command line, various IDEs assume also add `-DCMAKE_BUILD_TYPE=Debug` to create a debugable executable.

Right now the CMakeLists.txt prevent this.  First, it sets CMAKE_BUILD_TYPE, which overrides whatever is set on the command line.  Second, it forces `-O3` optimization, which makes debugging difficult.

This PR addresses these problems by:
- only setting CMAKE_BUILD_TYPE when it is not already specified
- only setting `-O3` optimization if `CMAKE_BUILD_TYPE` is not `Debug`.
