### PR TITLE
Find plugins on linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ if(APPLE)
 
 	# Seems necessary from macOS 10.15
 	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+elseif(UNIX)
+        # This tells libhmsbeagle.so to search the same directory to find plugins.
+        SET(CMAKE_INSTALL_RPATH "\$ORIGIN")
+        # $ORIGIN/{CPU,GPU,JNI} is so that libhmsbeagle.so can find the plugins in their build location.
+        # $ORIGIN/../libhmsbeagle is so that examples/* can find libhmsbeagle.so
+	SET(CMAKE_BUILD_RPATH "\$ORIGIN:\$ORIGIN/CPU:\$ORIGIN/GPU:\$ORIGIN/JNI:\$ORIGIN/../libhmsbeagle")
 endif(APPLE)
 
 if (BEAGLE_OPTIMIZE_FOR_NATIVE_ARCH)


### PR DESCRIPTION
This patch is semi-analogous to Mac line:
```
        # Seems necessary from macOS 10.15
        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
```

It contains two parts.

1. First, the RPATH of the installed `libhmsbeagle.so` is set to `$ORIGIN` so that it looks for plugins in the same directory as itself.  The RPATH is searched before LD_LIBRARY_PATH.  

The benefit of this is that if there is a different beagle installation (in /usr/local/ for example) `libhmsbeagle.so` will use the plugins in the same directory as itself in preference to the ones in /usr/local.

2. CMake also has the ability to set the RPATH for `libhmsbeagle.so` in the build directory _before_ installation.  Such RPATHS are used to run executables before installation and are erased during installation.

The benefit of setting RPATH in the build directory is so that when we run the examples (i.e. ./build/examples/hmctest) they will know how to find the plugins.