### PR TITLE
Use native linux-arm runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - "*"
   pull_request:
     branches:
-    - master
+    - "*"
 
 jobs:
   build:
@@ -32,28 +32,21 @@ jobs:
 
   build-aarch64:
     name: Build on Linux aarch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake file
+
     - name: Build
-      uses: uraimo/run-on-arch-action@v2
-      with:
-        arch: aarch64
-        distro: ubuntu20.04
-        githubToken: ${{ github.token }}
-        dockerRunArgs: |
-          --volume "${PWD}:/beagle-lib"
-        install: |
-          apt-get update -q -y
-          apt-get install -q -y cmake gcc g++ openjdk-11-jdk file
-        run: |
-          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
-          cd /beagle-lib
-          mkdir build
-          cd build
-          cmake ..
-          make -j
-          file libhmsbeagle/libhmsbeagle.so.* | grep aarch64
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make -j
+        file libhmsbeagle/libhmsbeagle.so.* | grep aarch64


### PR DESCRIPTION
Github now offers native ARM runners.  Add back the ARM Linux test, but now using the same testing code as on Intel Linux.