### PR TITLE
Set Automatic-Module-Name to 'beagle' in published JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,9 @@
                             <mainClass>beagle.BeagleFactory</mainClass>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>beagle</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                     <includes>
                         <include>**/*.class</include>


### PR DESCRIPTION
## Summary

Adds `Automatic-Module-Name: beagle` to the JAR manifest produced by the Maven build.

Without this, the published `beagle-1.0.0.jar` is treated by JPMS as a *filename-based automodule*: the module name is derived from the JAR filename, which is unstable (renaming the jar silently breaks every downstream `requires beagle;` clause). Recent Maven versions give this warning:

```
[WARNING] Required filename-based automodules detected: [beagle-1.0.0.jar]. Please don't publish this project to a public artifact repository!
```

Downstream projects in the BEAST ecosystem (feast, remaster, bdmm-prime, beast3, …) hit this warning and are concerned about publishing because of it.

## Why `beagle` as the module name

JPMS already derives `beagle` from the filename today, so any consumer with `requires beagle;` is implicitly relying on that name. Locking it in as the explicit `Automatic-Module-Name` makes the name stable without breaking any existing downstream `module-info.java`. The name also matches the existing Java package (`beagle.*`).

A reverse-DNS form (e.g. `io.github.beagledev.beagle`) is the JPMS-purist choice, but would require every downstream consumer to update their module declarations, so the short name is simpler.

## Test plan

- [ ] `mvn clean package` succeeds locally
- [ ] `unzip -p lib/beagle.jar META-INF/MANIFEST.MF | grep Automatic-Module-Name` shows `Automatic-Module-Name: beagle`
- [ ] Building a downstream project (e.g. feast) against the locally-installed JAR no longer emits the filename-based automodule warning